### PR TITLE
Fix capability value parsing for ZERO values

### DIFF
--- a/drivers/grott/device.ts
+++ b/drivers/grott/device.ts
@@ -41,7 +41,7 @@ class Grott extends Homey.Device {
 
         if (!mapping.divide) {
           await this.setCapabilityValue(mapping.capability, value);
-        } else if (Number(value)) {
+        } else if (value === 0 || Number(value)) {
           await this.setCapabilityValue(mapping.capability, value / 10);
         } else {
           this.error(`Failed to parse ${mapping.property} NaN`, value);


### PR DESCRIPTION
Small bug in the code fixed to handle the if statement when value = 0.
Number(0) would equal to false and 0 values cause the logic to "fail to parse".

Here is a fix for https://github.com/wimhaanstra/com.sortedbits.grott/issues/1

```
Before fix:
2025-01-18T07:32:06.805Z [log] [ManagerDrivers] [Driver:grott] GrottDriver has been initialized
2025-01-18T07:32:06.823Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Grott has been initialized
2025-01-18T07:32:06.839Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Connecting to broker mqtt://mqtt.local:1883
2025-01-18T07:32:07.260Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Connected to broker mqtt://mqtt.local:1883, subscribing to energy/growatt
2025-01-18T07:32:07.308Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Succesfully subscribed to growatt
2025-01-18T07:35:22.022Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Received packet in growatt: 703
2025-01-18T07:35:22.029Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting measure_power to 0
2025-01-18T07:35:22.036Z [err] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Failed to parse pvpowerout NaN 0
2025-01-18T07:35:22.043Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting serial_number.datalogger to SNlogger
2025-01-18T07:35:22.050Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting serial_number.pv to SNgrowatt
2025-01-18T07:35:22.054Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting measure_voltage.grid1 to 2308
2025-01-18T07:35:22.078Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting measure_current.grid1 to 0
2025-01-18T07:35:22.080Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting measure_power.grid1 to 0
2025-01-18T07:35:22.079Z [err] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Failed to parse pvgridcurrent NaN 0
2025-01-18T07:35:22.081Z [err] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Failed to parse pvgridpower NaN 0
2025-01-18T07:35:22.082Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting measure_voltage.grid2 to 2295
2025-01-18T07:35:22.099Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting measure_current.grid2 to 0
2025-01-18T07:35:22.101Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting measure_power.grid2 to 0
2025-01-18T07:35:22.102Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting measure_voltage.grid3 to 2327
2025-01-18T07:35:22.100Z [err] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Failed to parse pvgridcurrent2 NaN 0
2025-01-18T07:35:22.101Z [err] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Failed to parse pvgridpower2 NaN 0
2025-01-18T07:35:22.119Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting measure_current.grid3 to 0
2025-01-18T07:35:22.120Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting measure_power.grid3 to 0
2025-01-18T07:35:22.122Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting measure_voltage.pv1 to 3257
2025-01-18T07:35:22.119Z [err] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Failed to parse pvgridcurrent3 NaN 0
2025-01-18T07:35:22.121Z [err] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Failed to parse pvgridpower3 NaN 0
2025-01-18T07:35:22.136Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting measure_current.pv1 to 0
2025-01-18T07:35:22.138Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting measure_power.pv1 to 0
2025-01-18T07:35:22.139Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting measure_voltage.pv2 to 1966
2025-01-18T07:35:22.137Z [err] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Failed to parse pv1current NaN 0
2025-01-18T07:35:22.138Z [err] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Failed to parse pv1watt NaN 0
2025-01-18T07:35:22.154Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting measure_current.pv2 to 0
2025-01-18T07:35:22.157Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting measure_power.pv2 to 0
2025-01-18T07:35:22.155Z [err] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Failed to parse pv2current NaN 0
2025-01-18T07:35:22.158Z [err] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Failed to parse pv2watt NaN 0
2025-01-18T07:35:22.159Z [err] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Failed to parse pvenergytoday NaN 0
2025-01-18T07:35:22.158Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting meter_today_power to 0
2025-01-18T07:35:22.159Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting meter_power to 7774
2025-01-18T07:35:22.161Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Data from MQTT parsed

After fix:
2025-01-18T07:57:42.543Z [log] [ManagerDrivers] [Driver:grott] GrottDriver has been initialized
2025-01-18T07:57:42.565Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Grott has been initialized
2025-01-18T07:57:42.571Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Connecting to broker mqtt://mqtt.local:1883
2025-01-18T07:57:42.955Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Connected to broker mqtt://mqtt.local:1883, subscribing to energy/growatt
2025-01-18T07:57:43.004Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Succesfully subscribed to growatt
2025-01-18T08:00:22.543Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Received packet in growatt: 703
2025-01-18T08:00:22.549Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting measure_power to 0
2025-01-18T08:00:22.559Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting serial_number.datalogger to SNlogger
2025-01-18T08:00:22.565Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting serial_number.pv to SNgrowatt
2025-01-18T08:00:22.567Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting measure_voltage.grid1 to 2268
2025-01-18T08:00:22.582Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting measure_current.grid1 to 0
2025-01-18T08:00:22.584Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting measure_power.grid1 to 0
2025-01-18T08:00:22.585Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting measure_voltage.grid2 to 2291
2025-01-18T08:00:22.597Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting measure_current.grid2 to 0
2025-01-18T08:00:22.599Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting measure_power.grid2 to 0
2025-01-18T08:00:22.604Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting measure_voltage.grid3 to 2318
2025-01-18T08:00:22.618Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting measure_current.grid3 to 0
2025-01-18T08:00:22.620Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting measure_power.grid3 to 0
2025-01-18T08:00:22.621Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting measure_voltage.pv1 to 3592
2025-01-18T08:00:22.633Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting measure_current.pv1 to 0
2025-01-18T08:00:22.635Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting measure_power.pv1 to 0
2025-01-18T08:00:22.636Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting measure_voltage.pv2 to 2010
2025-01-18T08:00:22.652Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting measure_current.pv2 to 0
2025-01-18T08:00:22.653Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting measure_power.pv2 to 0
2025-01-18T08:00:22.656Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting meter_today_power to 0
2025-01-18T08:00:22.658Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Setting meter_power to 7774
2025-01-18T08:00:22.662Z [log] [ManagerDrivers] [Driver:grott] [Device:949518e33bcc] Data from MQTT parsed

```